### PR TITLE
Make kernel builds deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Changed
+- Make kernel build timestamp deterministic
 
 ## [0.16.0] - 2023-03-30
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,9 @@ FROM ${TOOLCHAIN_REPOSITORY}:${TOOLCHAIN_VERSION}
 
 LABEL maintainer="Diego Nehab <diego@cartesi.io>"
 
-ARG KERNEL_VERSION=5.15.63-ctsi-2
-ARG RISCV_PK_VERSION=1.0.0-ctsi-1
+ARG KERNEL_VERSION=0.0.0-ctsi-y
+ARG KERNEL_TIMESTAMP="Thu, 01 Jan 1970 00:00:00 +0000"
+ARG RISCV_PK_VERSION=0.0.0-ctsi-y
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -53,7 +54,7 @@ RUN tar xzf ${BUILD_BASE}/dep/riscv-pk-${RISCV_PK_VERSION}.tar.gz \
 COPY cartesi-linux-config ${BUILD_BASE}/work/linux/.config
 
 COPY build.mk build.mk
-RUN make -f build.mk
+RUN make -f build.mk KERNEL_TIMESTAMP="${KERNEL_TIMESTAMP}"
 
 USER root
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@
 TAG ?= devel
 TOOLCHAIN_DOCKER_REPOSITORY ?= cartesi/toolchain
 TOOLCHAIN_TAG ?= 0.13.0
+KERNEL_TIMESTAMP ?= $(shell date -Rud @$(shell git log -1 --format=%ct 2> /dev/null || date +%s))
 KERNEL_VERSION ?= 5.15.63-ctsi-2
 KERNEL_SRCPATH := dep/linux-${KERNEL_VERSION}.tar.gz
 RISCV_PK_VERSION ?= 1.0.0-ctsi-1
@@ -45,6 +46,10 @@ endif
 
 ifneq ($(KERNEL_VERSION),)
 BUILD_ARGS += --build-arg KERNEL_VERSION=$(KERNEL_VERSION)
+endif
+
+ifneq ($(KERNEL_TIMESTAMP),)
+BUILD_ARGS += --build-arg KERNEL_TIMESTAMP="$(KERNEL_TIMESTAMP)"
 endif
 
 ifneq ($(RISCV_PK_VERSION),)


### PR DESCRIPTION
Before this commit, every time I cleaned Docker cache and build the kernel from scratch the generated binary files and artifacts would end up with different sha1sum. This PR fixes this by making use of `KBUILD_BUILD_TIMESTAMP` with its  value set to the latest git commit timestamp. This is enough to make the kernel build reproducible in my machine after I clean my docker cache. I also use the same timestamp in headers and selftest tarballs to make them reproducible.

Proof:

```
➜  make && sha1sum linux-*
shasum -ca 256 shasumfile
dep/linux-5.15.63-ctsi-2.tar.gz: OK
dep/riscv-pk-1.0.0-ctsi-1.tar.gz: OK
docker build -t cartesi/linux-kernel:devel --build-arg TOOLCHAIN_REPOSITORY=cartesi/toolchain --build-arg TOOLCHAIN_VERSION=0.13.0 --build-arg KERNEL_VERSION=5.15.63-ctsi-2 --build-arg KERNEL_TIMESTAMP="Wed, 10 May 2023 16:27:04 +0000" --build-arg RISCV_PK_VERSION=1.0.0-ctsi-1 .
[+] Building 185.4s (16/16) FINISHED                                                                                                          
 => [internal] load build definition from Dockerfile                                                                                     0.1s
 => => transferring dockerfile: 2.14kB                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                        0.1s
 => => transferring context: 94B                                                                                                         0.0s
 => [internal] load metadata for docker.io/cartesi/toolchain:0.13.0                                                                      0.0s
 => CACHED [ 1/11] FROM docker.io/cartesi/toolchain:0.13.0                                                                               0.0s
 => [internal] load build context                                                                                                        0.1s
 => => transferring context: 4.10kB                                                                                                      0.0s
 => [ 2/11] RUN   mkdir -p /opt/riscv/kernel/artifacts &&   chown -R developer:developer /opt/riscv/kernel &&   chmod go+w /opt/riscv/k  0.4s
 => [ 3/11] WORKDIR /opt/riscv/kernel                                                                                                    0.1s
 => [ 4/11] COPY --chown=developer:developer dep/linux-5.15.63-ctsi-2.tar.gz /opt/riscv/kernel/dep/                                      0.7s
 => [ 5/11] RUN tar xzf /opt/riscv/kernel/dep/linux-5.15.63-ctsi-2.tar.gz   --strip-components=1 --one-top-level=/opt/riscv/kernel/work  9.0s
 => [ 6/11] COPY --chown=developer:developer dep/riscv-pk-1.0.0-ctsi-1.tar.gz /opt/riscv/kernel/dep/                                     0.1s
 => [ 7/11] RUN tar xzf /opt/riscv/kernel/dep/riscv-pk-1.0.0-ctsi-1.tar.gz   --strip-components=1 --one-top-level=/opt/riscv/kernel/wor  0.4s
 => [ 8/11] COPY cartesi-linux-config /opt/riscv/kernel/work/linux/.config                                                               0.3s
 => [ 9/11] COPY build.mk build.mk                                                                                                       0.1s
 => [10/11] RUN make -f build.mk KERNEL_TIMESTAMP="Wed, 10 May 2023 16:27:04 +0000"                                                    150.1s
 => [11/11] WORKDIR /opt/riscv                                                                                                           0.1s
 => exporting to image                                                                                                                  23.6s 
 => => exporting layers                                                                                                                 23.6s 
 => => writing image sha256:29d9bf8db3b7611bc3a073ad900d3435a36827a88d014449bcc2261dee680ac7                                             0.0s 
 => => naming to docker.io/cartesi/linux-kernel:devel                                                                                    0.0s 
ID=`docker create cartesi/linux-kernel:devel` && \                                                                                            
   docker cp $ID:/opt/riscv/kernel/artifacts/linux-headers-5.15.63-ctsi-2.tar.xz  . && \
   docker cp $ID:/opt/riscv/kernel/artifacts/linux-nobbl-5.15.63-ctsi-2.bin    . && \
   docker cp $ID:/opt/riscv/kernel/artifacts/linux-5.15.63-ctsi-2.bin    . && \
   docker cp $ID:/opt/riscv/kernel/artifacts/linux-5.15.63-ctsi-2.elf . && \
   docker cp $ID:/opt/riscv/kernel/artifacts/linux-selftest-5.15.63-ctsi-2.ext2 . && \
   docker rm -v $ID
Successfully copied 1.14MB to /home/bart/projects/cartesi/corp/machine-emulator-sdk/kernel/.
Successfully copied 13.3MB to /home/bart/projects/cartesi/corp/machine-emulator-sdk/kernel/.
Successfully copied 15.6MB to /home/bart/projects/cartesi/corp/machine-emulator-sdk/kernel/.
Successfully copied 6.56MB to /home/bart/projects/cartesi/corp/machine-emulator-sdk/kernel/.
Successfully copied 1.05MB to /home/bart/projects/cartesi/corp/machine-emulator-sdk/kernel/.
d9574ef49eb660f2bd3bd76a580ce828ef11c5d5de2730a339abe6ead3ce7488
0aa033445a166ab3a2fd4c5131149ecba87178a5  linux-5.15.63-ctsi-2.bin
a727f07e233220ed90eb41f77651e771550e6647  linux-5.15.63-ctsi-2.elf
93b091c4a6a449147487f9354144b5ecd27fe05b  linux-headers-5.15.63-ctsi-2.tar.xz
a1d654b8a84b1dafd26260ecafa755ee746ef5a8  linux-nobbl-5.15.63-ctsi-2.bin
215f0fd67556f8d06b536dac26aab29329539b45  linux-selftest-5.15.63-ctsi-2.ext2
➜  docker rmi cartesi/linux-kernel:devel  && docker system prune
Untagged: cartesi/linux-kernel:devel
Deleted: sha256:29d9bf8db3b7611bc3a073ad900d3435a36827a88d014449bcc2261dee680ac7
WARNING! This will remove:
  - all stopped containers
  - all networks not used by at least one container
  - all dangling images
  - all dangling build cache

Are you sure you want to continue? [y/N] y
Deleted Images:
deleted: sha256:eba54ecb6c12a04c1f228d20065e91b8d321aaba7bca93850329e69175af87c9

Deleted build cache objects:
mlcqtinjl8qppvxa9b1vr69y8
j9v79sfkdg95r10sqtm1ce1fo
px1abs7sd4zp0l77mppge9wik
z7sg361spbpbl09dos0s3bri5
lqnjwtion2uc3712ezzpr0z53
w3kckp2r4pycl1s59dzjcb1ky
mirkgad0m7rubdu8lrfc288wf
5f3p5u5kccpwyo86412lg99rc
pm0z7c7gftoxcar7nipe2ncci
sq1n1q8q4z1re7y8az100v60w
oj7hm3szmk7xzi9jmx17t5lrd
mhv2fo459fvboiby0ul3wz4ms
tlpfd0vpqdr30js2uta13pitp
tkm2dnwclbk8po0dw911hhxis
mvnfr2dvjqmuk5ggb2l85dzo6
xaupkldkyv75sa7z91bl05x63
mmohakpeohskhpgtykhp5f4en
y8l6jxzkmfz3twb66uljr1pcc
p1tl1wzvjin984xf34ghleggb
dcy28u1mps7z2ig7s7qe6j2kf
klf36bnks09ilgpxl6e3blbzt
yshyldocbt6f7e02dyb7cea8k
u98mkgs8dt12n7ww98yrwrbo2

Total reclaimed space: 3.201GB
➜  make && sha1sum linux-*
shasum -ca 256 shasumfile
dep/linux-5.15.63-ctsi-2.tar.gz: OK
dep/riscv-pk-1.0.0-ctsi-1.tar.gz: OK
docker build -t cartesi/linux-kernel:devel --build-arg TOOLCHAIN_REPOSITORY=cartesi/toolchain --build-arg TOOLCHAIN_VERSION=0.13.0 --build-arg KERNEL_VERSION=5.15.63-ctsi-2 --build-arg KERNEL_TIMESTAMP="Wed, 10 May 2023 16:27:04 +0000" --build-arg RISCV_PK_VERSION=1.0.0-ctsi-1 .
[+] Building 184.8s (16/16) FINISHED                                                                                                          
 => [internal] load build definition from Dockerfile                                                                                     0.4s
 => => transferring dockerfile: 2.14kB                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                        0.6s
 => => transferring context: 94B                                                                                                         0.0s
 => [internal] load metadata for docker.io/cartesi/toolchain:0.13.0                                                                      0.0s
 => CACHED [ 1/11] FROM docker.io/cartesi/toolchain:0.13.0                                                                               0.0s
 => [internal] load build context                                                                                                        1.8s
 => => transferring context: 198.90MB                                                                                                    1.6s
 => [ 2/11] RUN   mkdir -p /opt/riscv/kernel/artifacts &&   chown -R developer:developer /opt/riscv/kernel &&   chmod go+w /opt/riscv/k  0.6s
 => [ 3/11] WORKDIR /opt/riscv/kernel                                                                                                    0.4s
 => [ 4/11] COPY --chown=developer:developer dep/linux-5.15.63-ctsi-2.tar.gz /opt/riscv/kernel/dep/                                      1.5s
 => [ 5/11] RUN tar xzf /opt/riscv/kernel/dep/linux-5.15.63-ctsi-2.tar.gz   --strip-components=1 --one-top-level=/opt/riscv/kernel/work  9.1s
 => [ 6/11] COPY --chown=developer:developer dep/riscv-pk-1.0.0-ctsi-1.tar.gz /opt/riscv/kernel/dep/                                     0.1s
 => [ 7/11] RUN tar xzf /opt/riscv/kernel/dep/riscv-pk-1.0.0-ctsi-1.tar.gz   --strip-components=1 --one-top-level=/opt/riscv/kernel/wor  0.4s
 => [ 8/11] COPY cartesi-linux-config /opt/riscv/kernel/work/linux/.config                                                               0.2s
 => [ 9/11] COPY build.mk build.mk                                                                                                       0.1s
 => [10/11] RUN make -f build.mk KERNEL_TIMESTAMP="Wed, 10 May 2023 16:27:04 +0000"                                                    149.3s
 => [11/11] WORKDIR /opt/riscv                                                                                                           0.1s 
 => exporting to image                                                                                                                  21.5s 
 => => exporting layers                                                                                                                 21.4s 
 => => writing image sha256:c89a19ecc404b2687fd2a4a89a7208ecf69fdd7300a4dbd351eed75117b62039                                             0.0s 
 => => naming to docker.io/cartesi/linux-kernel:devel                                                                                    0.0s 
ID=`docker create cartesi/linux-kernel:devel` && \                                                                                            
   docker cp $ID:/opt/riscv/kernel/artifacts/linux-headers-5.15.63-ctsi-2.tar.xz  . && \
   docker cp $ID:/opt/riscv/kernel/artifacts/linux-nobbl-5.15.63-ctsi-2.bin    . && \
   docker cp $ID:/opt/riscv/kernel/artifacts/linux-5.15.63-ctsi-2.bin    . && \
   docker cp $ID:/opt/riscv/kernel/artifacts/linux-5.15.63-ctsi-2.elf . && \
   docker cp $ID:/opt/riscv/kernel/artifacts/linux-selftest-5.15.63-ctsi-2.ext2 . && \
   docker rm -v $ID
Successfully copied 1.14MB to /home/bart/projects/cartesi/corp/machine-emulator-sdk/kernel/.
Successfully copied 13.3MB to /home/bart/projects/cartesi/corp/machine-emulator-sdk/kernel/.
Successfully copied 15.6MB to /home/bart/projects/cartesi/corp/machine-emulator-sdk/kernel/.
Successfully copied 6.56MB to /home/bart/projects/cartesi/corp/machine-emulator-sdk/kernel/.
Successfully copied 1.05MB to /home/bart/projects/cartesi/corp/machine-emulator-sdk/kernel/.
4bd87f3937d372a7d2f6de3c05ef02594903a3b59f0283a91ef564590726f618
0aa033445a166ab3a2fd4c5131149ecba87178a5  linux-5.15.63-ctsi-2.bin
a727f07e233220ed90eb41f77651e771550e6647  linux-5.15.63-ctsi-2.elf
93b091c4a6a449147487f9354144b5ecd27fe05b  linux-headers-5.15.63-ctsi-2.tar.xz
a1d654b8a84b1dafd26260ecafa755ee746ef5a8  linux-nobbl-5.15.63-ctsi-2.bin
215f0fd67556f8d06b536dac26aab29329539b45  linux-selftest-5.15.63-ctsi-2.ext2
```

Notice that above I build kernel twice, in both builds it generate artifacts with exact same sha1sum with following hashes:
```
0aa033445a166ab3a2fd4c5131149ecba87178a5  linux-5.15.63-ctsi-2.bin
a727f07e233220ed90eb41f77651e771550e6647  linux-5.15.63-ctsi-2.elf
93b091c4a6a449147487f9354144b5ecd27fe05b  linux-headers-5.15.63-ctsi-2.tar.xz
a1d654b8a84b1dafd26260ecafa755ee746ef5a8  linux-nobbl-5.15.63-ctsi-2.bin
215f0fd67556f8d06b536dac26aab29329539b45  linux-selftest-5.15.63-ctsi-2.ext2
```
This did not happen before this commit.
