### PR TITLE
Updated CI download

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,14 +1,13 @@
 name: Build
 on: [push]
-env:
-  KERNEL_VERSION: 5.15.63-ctsi-2
-  RISCV_PK_VERSION: 1.0.0-ctsi-1
-  TOOLCHAIN_VERSION: 0.13.0
 jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+
+      - name: Retrieve environment variables
+        run: make env >> $GITHUB_ENV
 
       - name: Copy default Cartesi Linux config
         run: make cartesi-linux-config
@@ -37,7 +36,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download dependencies
-        run: make download checksum
+        run: make download
 
       - name: Build docker image
         id: docker_build
@@ -53,6 +52,7 @@ jobs:
             TOOLCHAIN_REPOSITORY=${{ secrets.DOCKER_ORGANIZATION }}/toolchain
             TOOLCHAIN_VERSION=${{ env.TOOLCHAIN_VERSION }}
             KERNEL_VERSION=${{ env.KERNEL_VERSION }}
+            IMAGE_KERNEL_VERSION=${{ env.IMAGE_KERNEL_VERSION }}
             RISCV_PK_VERSION=${{ env.RISCV_PK_VERSION }}
           cache-from: type=gha,mode=xmax,scope=regular
           cache-to: type=gha,scope=regular
@@ -60,53 +60,19 @@ jobs:
       - name: Export artifacts
         run: make copy IMG=`echo "${{ steps.docker_meta.outputs.tags }}" | head -1 | cut -d "," -f 1 | xargs`
 
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          path: artifacts/*
+
       - uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/v')
         with:
           prerelease: true
           files: |
-            linux-headers-${{ env.KERNEL_VERSION }}.tar.xz
-            linux-nobbl-${{ env.KERNEL_VERSION }}.bin
-            linux-${{ env.KERNEL_VERSION }}.bin
-            linux-selftest-${{ env.KERNEL_VERSION }}.ext2
+            artifacts/*
         env:
           GITHUB_TOKEN: ${{ secrets.CI_TOKEN }}
-
-      - name: Upload [linux-headers-${{ env.KERNEL_VERSION }}.tar.xz]
-        uses: actions/upload-artifact@v3
-        with:
-          name: linux-headers-${{ env.KERNEL_VERSION }}.tar.xz
-          path: linux-headers-${{ env.KERNEL_VERSION }}.tar.xz
-
-      - name: Upload [linux-nobbl-${{ env.KERNEL_VERSION }}.bin]
-        uses: actions/upload-artifact@v3
-        with:
-          name: linux-nobbl-${{ env.KERNEL_VERSION }}.bin
-          path: linux-nobbl-${{ env.KERNEL_VERSION }}.bin
-
-      - name: Upload [linux-${{ env.KERNEL_VERSION }}.bin]
-        uses: actions/upload-artifact@v3
-        with:
-          name: linux-${{ env.KERNEL_VERSION }}.bin
-          path: linux-${{ env.KERNEL_VERSION }}.bin
-
-      - name: Upload [linux-selftest-${{ env.KERNEL_VERSION }}.ext2]
-        uses: actions/upload-artifact@v3
-        with:
-          name: linux-selftest-${{ env.KERNEL_VERSION }}.ext2
-          path: linux-selftest-${{ env.KERNEL_VERSION }}.ext2
-
-      - name: Upload [linux-libc-dev-${{ env.KERNEL_VERSION }}.deb]
-        uses: actions/upload-artifact@v3
-        with:
-          name: linux-libc-dev-${{ env.KERNEL_VERSION }}.deb
-          path: linux-libc-dev-${{ env.KERNEL_VERSION }}.deb
-
-      - name: Upload [linux-libc-dev-riscv64-cross-${{ env.KERNEL_VERSION }}.deb]
-        uses: actions/upload-artifact@v3
-        with:
-          name: linux-libc-dev-riscv64-cross-${{ env.KERNEL_VERSION }}.deb
-          path: linux-libc-dev-riscv64-cross-${{ env.KERNEL_VERSION }}.deb
 
       - name: Push docker image
         id: docker_push
@@ -123,6 +89,7 @@ jobs:
             TOOLCHAIN_REPOSITORY=${{ secrets.DOCKER_ORGANIZATION }}/toolchain
             TOOLCHAIN_VERSION=${{ env.TOOLCHAIN_VERSION }}
             KERNEL_VERSION=${{ env.KERNEL_VERSION }}
+            IMAGE_KERNEL_VERSION=${{ env.IMAGE_KERNEL_VERSION }}
             RISCV_PK_VERSION=${{ env.RISCV_PK_VERSION }}
           cache-from: type=gha,mode=max,scope=regular
           cache-to: type=gha,scope=regular

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,20 +32,12 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Download linux
-        run: >
-          gh release download -D dep/ -R ${{ github.repository_owner }}/linux v${{ env.KERNEL_VERSION }} --archive=tar.gz
-        env:
-          GITHUB_TOKEN: ${{ secrets.CI_TOKEN }}
-
-      - name: Download riscv-pk
-        run: >
-          gh release download -D dep/ -R ${{ github.repository_owner }}/riscv-pk v${{ env.RISCV_PK_VERSION }} --archive=tar.gz
-        env:
-          GITHUB_TOKEN: ${{ secrets.CI_TOKEN }}
+      - name: Download dependencies
+        run: make download checksum
 
       - name: Build docker image
         id: docker_build
@@ -79,6 +71,30 @@ jobs:
             linux-selftest-${{ env.KERNEL_VERSION }}.ext2
         env:
           GITHUB_TOKEN: ${{ secrets.CI_TOKEN }}
+
+      - name: Upload [linux-headers-${{ env.KERNEL_VERSION }}.tar.xz]
+        uses: actions/upload-artifact@v3
+        with:
+          name: linux-headers-${{ env.KERNEL_VERSION }}.tar.xz
+          path: linux-headers-${{ env.KERNEL_VERSION }}.tar.xz
+
+      - name: Upload [linux-nobbl-${{ env.KERNEL_VERSION }}.bin]
+        uses: actions/upload-artifact@v3
+        with:
+          name: linux-nobbl-${{ env.KERNEL_VERSION }}.bin
+          path: linux-nobbl-${{ env.KERNEL_VERSION }}.bin
+
+      - name: Upload [linux-${{ env.KERNEL_VERSION }}.bin]
+        uses: actions/upload-artifact@v3
+        with:
+          name: linux-${{ env.KERNEL_VERSION }}.bin
+          path: linux-${{ env.KERNEL_VERSION }}.bin
+
+      - name: Upload [linux-selftest-${{ env.KERNEL_VERSION }}.ext2]
+        uses: actions/upload-artifact@v3
+        with:
+          name: linux-selftest-${{ env.KERNEL_VERSION }}.ext2
+          path: linux-selftest-${{ env.KERNEL_VERSION }}.ext2
 
       - name: Push docker image
         id: docker_push

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,29 +8,29 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Copy default Cartesi Linux config
         run: make cartesi-linux-config
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Docker meta
         id: docker_meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ secrets.DOCKER_ORGANIZATION }}/linux-kernel
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
+      - name: Login to GHCR
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build docker image
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
           builder: ${{ steps.buildx.outputs.name }}
@@ -57,7 +57,7 @@ jobs:
           cache-from: type=gha,mode=xmax,scope=regular
           cache-to: type=gha,scope=regular
 
-      - name: Export linux.bin artifact
+      - name: Export artifacts
         run: make copy IMG=`echo "${{ steps.docker_meta.outputs.tags }}" | head -1 | cut -d "," -f 1 | xargs`
 
       - uses: softprops/action-gh-release@v1
@@ -98,7 +98,7 @@ jobs:
 
       - name: Push docker image
         id: docker_push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         if: ${{ startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/develop') }}
         with:
           context: .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,6 +96,18 @@ jobs:
           name: linux-selftest-${{ env.KERNEL_VERSION }}.ext2
           path: linux-selftest-${{ env.KERNEL_VERSION }}.ext2
 
+      - name: Upload [linux-libc-dev-${{ env.KERNEL_VERSION }}.deb]
+        uses: actions/upload-artifact@v3
+        with:
+          name: linux-libc-dev-${{ env.KERNEL_VERSION }}.deb
+          path: linux-libc-dev-${{ env.KERNEL_VERSION }}.deb
+
+      - name: Upload [linux-libc-dev-riscv64-cross-${{ env.KERNEL_VERSION }}.deb]
+        uses: actions/upload-artifact@v3
+        with:
+          name: linux-libc-dev-riscv64-cross-${{ env.KERNEL_VERSION }}.deb
+          path: linux-libc-dev-riscv64-cross-${{ env.KERNEL_VERSION }}.deb
+
       - name: Push docker image
         id: docker_push
         uses: docker/build-push-action@v4

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ linux-*.bin
 linux-nobbl-*.bin
 linux-headers-*.tar.xz
 linux-selftest-*.ext2
+linux-libc-dev-*.deb
 cartesi-linux-config
 dep

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,4 @@
-linux-*.elf
-linux-*.bin
-linux-nobbl-*.bin
-linux-headers-*.tar.xz
-linux-selftest-*.ext2
-linux-libc-dev-*.deb
+artifacts/*
+linux-*.tar.gz
+riscv-pk-*.tar.gz
 cartesi-linux-config
-dep

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated license/copyright notice in all source code
 - Updated CI downloads to public infrastructure
 - Updated CI actions versions
+- Added deb generation and upload to CI as artifact
 
 ## [0.16.0] - 2023-03-30
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Changed
 - Make kernel build timestamp deterministic
 - Updated license/copyright notice in all source code
+- Updated CI downloads to public infrastructure
+- Updated CI actions versions
 
 ## [0.16.0] - 2023-03-30
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,18 @@ RUN tar xzf ${BUILD_BASE}/dep/riscv-pk-${RISCV_PK_VERSION}.tar.gz \
 
 COPY cartesi-linux-config ${BUILD_BASE}/work/linux/.config
 
+# build
+# ------------------------------------------------------------------------------
 COPY build.mk build.mk
 RUN make -f build.mk KERNEL_TIMESTAMP="${KERNEL_TIMESTAMP}"
+
+# deb headers
+# ------------------------------------------------------------------------------
+COPY tools tools
+RUN make -f build.mk KERNEL_TIMESTAMP="${KERNEL_TIMESTAMP}" DESTDIR=${BUILD_BASE}/work/_install cross-deb \
+	&& rm -rf ${BUILD_BASE}/work/_install
+RUN make -f build.mk KERNEL_TIMESTAMP="${KERNEL_TIMESTAMP}" DESTDIR=${BUILD_BASE}/work/_install native-deb \
+	&& rm -rf ${BUILD_BASE}/work/_install
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,14 +40,14 @@ USER developer
 
 # copy kernel
 # ------------------------------------------------------------------------------
-COPY --chown=developer:developer dep/linux-${KERNEL_VERSION}.tar.gz ${BUILD_BASE}/dep/
+COPY --chown=developer:developer linux-${KERNEL_VERSION}.tar.gz ${BUILD_BASE}/dep/
 RUN tar xzf ${BUILD_BASE}/dep/linux-${KERNEL_VERSION}.tar.gz \
   --strip-components=1 --one-top-level=${BUILD_BASE}/work/linux && \
   rm ${BUILD_BASE}/dep/linux-${KERNEL_VERSION}.tar.gz
 
 # copy riscv-pk
 # ------------------------------------------------------------------------------
-COPY --chown=developer:developer dep/riscv-pk-${RISCV_PK_VERSION}.tar.gz ${BUILD_BASE}/dep/
+COPY --chown=developer:developer riscv-pk-${RISCV_PK_VERSION}.tar.gz ${BUILD_BASE}/dep/
 RUN tar xzf ${BUILD_BASE}/dep/riscv-pk-${RISCV_PK_VERSION}.tar.gz \
   --strip-components=1 --one-top-level=${BUILD_BASE}/work/riscv-pk && \
   rm ${BUILD_BASE}/dep/riscv-pk-${RISCV_PK_VERSION}.tar.gz
@@ -56,16 +56,21 @@ COPY cartesi-linux-config ${BUILD_BASE}/work/linux/.config
 
 # build
 # ------------------------------------------------------------------------------
+ARG IMAGE_KERNEL_VERSION=0.0.0
 COPY build.mk build.mk
-RUN make -f build.mk KERNEL_TIMESTAMP="${KERNEL_TIMESTAMP}"
+RUN make -f build.mk KERNEL_TIMESTAMP="${KERNEL_TIMESTAMP}" IMAGE_KERNEL_VERSION="${IMAGE_KERNEL_VERSION}"
 
 # deb headers
 # ------------------------------------------------------------------------------
 COPY tools tools
-RUN make -f build.mk KERNEL_TIMESTAMP="${KERNEL_TIMESTAMP}" DESTDIR=${BUILD_BASE}/work/_install cross-deb \
-	&& rm -rf ${BUILD_BASE}/work/_install
-RUN make -f build.mk KERNEL_TIMESTAMP="${KERNEL_TIMESTAMP}" DESTDIR=${BUILD_BASE}/work/_install native-deb \
-	&& rm -rf ${BUILD_BASE}/work/_install
+RUN \
+  make -f build.mk KERNEL_TIMESTAMP="${KERNEL_TIMESTAMP}" IMAGE_KERNEL_VERSION="${IMAGE_KERNEL_VERSION}" \
+    DESTDIR=${BUILD_BASE}/work/_install cross-deb && \
+  rm -rf ${BUILD_BASE}/work/_install
+RUN \
+  make -f build.mk KERNEL_TIMESTAMP="${KERNEL_TIMESTAMP}" IMAGE_KERNEL_VERSION="${IMAGE_KERNEL_VERSION}" \
+    DESTDIR=${BUILD_BASE}/work/_install native-deb && \
+  rm -rf ${BUILD_BASE}/work/_install
 
 USER root
 

--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,13 @@ CONTAINER_BASE := /opt/cartesi/kernel
 IMG ?= cartesi/linux-kernel:$(TAG)
 BASE:=/opt/riscv
 
-HEADERS  := linux-headers-$(KERNEL_VERSION).tar.xz
-IMAGE    := linux-nobbl-$(KERNEL_VERSION).bin
-LINUX    := linux-$(KERNEL_VERSION).bin
-LINUX_ELF:= linux-$(KERNEL_VERSION).elf
-SELFTEST := linux-selftest-$(KERNEL_VERSION).ext2
+HEADERS    := linux-headers-$(KERNEL_VERSION).tar.xz
+IMAGE      := linux-nobbl-$(KERNEL_VERSION).bin
+LINUX      := linux-$(KERNEL_VERSION).bin
+LINUX_ELF  := linux-$(KERNEL_VERSION).elf
+SELFTEST   := linux-selftest-$(KERNEL_VERSION).ext2
+NATIVE_DEB := linux-libc-dev-$(KERNEL_VERSION).deb
+CROSS_DEB  := linux-libc-dev-riscv64-cross-$(KERNEL_VERSION).deb
 
 BUILD_ARGS :=
 
@@ -96,6 +98,8 @@ copy:
 	   docker cp $$ID:$(BASE)/kernel/artifacts/$(LINUX)    . && \
 	   docker cp $$ID:$(BASE)/kernel/artifacts/$(LINUX_ELF) . && \
 	   docker cp $$ID:$(BASE)/kernel/artifacts/$(SELFTEST) . && \
+	   docker cp $$ID:$(BASE)/kernel/artifacts/$(NATIVE_DEB) . && \
+	   docker cp $$ID:$(BASE)/kernel/artifacts/$(CROSS_DEB) . && \
 	   docker rm -v $$ID
 
 cartesi-linux-config:
@@ -105,7 +109,7 @@ clean-config:
 	rm -f ./cartesi-linux-config
 
 clean: clean-config
-	rm -f $(HEADERS) $(IMAGE) $(LINUX) $(LINUX_ELF) $(SELFTEST)
+	rm -f $(HEADERS) $(IMAGE) $(LINUX) $(LINUX_ELF) $(SELFTEST) $(NATIVE_DEB) $(CROSS_DEB)
 
 depclean: clean
 	rm -f \

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-.PHONY: all build push run pull share copy clean clean-config checksum
+.PHONY: all build download push run pull share copy clean clean-config checksum
 
 TAG ?= devel
 TOOLCHAIN_DOCKER_REPOSITORY ?= cartesi/toolchain
@@ -62,7 +62,7 @@ endif
 .NOTPARALLEL: all
 all: build copy
 
-build: cartesi-linux-config checksum
+build: cartesi-linux-config download
 	docker build -t $(IMG) $(BUILD_ARGS) .
 
 push:
@@ -113,6 +113,8 @@ depclean: clean
 
 checksum: $(KERNEL_SRCPATH) $(RISCV_PK_SRCPATH)
 	shasum -ca 256 shasumfile
+
+download: $(KERNEL_SRCPATH) $(RISCV_PK_SRCPATH)
 
 dep:
 	mkdir dep

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ clean-config:
 	rm -f ./cartesi-linux-config
 
 clean: clean-config
-	rm -f $(HEADERS) $(IMAGE) $(LINUX) $(SELFTEST)
+	rm -f $(HEADERS) $(IMAGE) $(LINUX) $(LINUX_ELF) $(SELFTEST)
 
 depclean: clean
 	rm -f \

--- a/build.mk
+++ b/build.mk
@@ -114,10 +114,10 @@ clone: LINUX_BRANCH ?= linux-5.15.63-ctsi-y
 clone: RISCV_PK_BRANCH ?= v1.0.0-ctsi-1
 clone:
 	git clone --depth 1 --branch $(LINUX_BRANCH) \
-		git@github.com:cartesi-corp/linux.git $(LINUX_DIR) || \
+		git@github.com:cartesi/linux.git $(LINUX_DIR) || \
 		cd $(LINUX_DIR) && git pull
 	git clone --depth 1 --branch $(RISCV_PK_BRANCH) \
-		git@github.com:cartesi-corp/riscv-pk.git $(RISCV_PK_DIR) || \
+		git@github.com:cartesi/riscv-pk.git $(RISCV_PK_DIR) || \
 		cd $(RISCV_PK_DIR) && git pull
 
 run: IMG=cartesi/toolchain:devel

--- a/build.mk
+++ b/build.mk
@@ -10,24 +10,31 @@ JOBS                := -j$(shell nproc)
 
 KERNEL_VERSION      ?= $(shell make -sC $(LINUX_DIR) kernelversion)
 KERNEL_TIMESTAMP    ?= $(shell date -Ru)
-HEADERS             := artifacts/linux-headers-$(KERNEL_VERSION).tar.xz
-IMAGE               := artifacts/linux-nobbl-$(KERNEL_VERSION).bin
-LINUX               := artifacts/linux-$(KERNEL_VERSION).bin
-LINUX_ELF           := artifacts/linux-$(KERNEL_VERSION).elf
-SELFTEST            := artifacts/linux-selftest-$(KERNEL_VERSION).ext2
-CROSS_DEB_FILENAME  := artifacts/linux-libc-dev-riscv64-cross-$(KERNEL_VERSION).deb
-NATIVE_DEB_FILENAME := artifacts/linux-libc-dev-$(KERNEL_VERSION).deb
+IMAGE_KERNEL_VERSION?= 0.0.0
+HEADERS             := artifacts/linux-headers-$(KERNEL_VERSION)-v$(IMAGE_KERNEL_VERSION).tar.xz
+IMAGE               := artifacts/linux-nobbl-$(KERNEL_VERSION)-v$(IMAGE_KERNEL_VERSION).bin
+LINUX               := artifacts/linux-$(KERNEL_VERSION)-v$(IMAGE_KERNEL_VERSION).bin
+LINUX_ELF           := artifacts/linux-$(KERNEL_VERSION)-v$(IMAGE_KERNEL_VERSION).elf
+SELFTEST            := artifacts/linux-selftest-$(KERNEL_VERSION)-v$(IMAGE_KERNEL_VERSION).ext2
+CROSS_DEB_FILENAME  := artifacts/linux-libc-dev-riscv64-cross-$(KERNEL_VERSION)-v$(IMAGE_KERNEL_VERSION).deb
+NATIVE_DEB_FILENAME := artifacts/linux-libc-dev-$(KERNEL_VERSION)-v$(IMAGE_KERNEL_VERSION).deb
 ARTIFACTS           := $(HEADERS) $(IMAGE) $(LINUX) $(SELFTEST)
 
 
 all: $(ARTIFACTS)
 
 env:
-	@echo export ARCH=riscv
-	@echo export CROSS_COMPILE=$(TOOLCHAIN_PREFIX)-
-	@echo export KBUILD_BUILD_TIMESTAMP="$(KERNEL_TIMESTAMP)"
-	@echo export KBUILD_BUILD_USER=dapp
-	@echo export KBUILD_BUILD_HOST=cartesi
+	@echo KBUILD_BUILD_TIMESTAMP=\""$(KERNEL_TIMESTAMP)"\"
+	@echo KBUILD_BUILD_USER=dapp
+	@echo KBUILD_BUILD_HOST=cartesi
+
+	@echo HEADERS="$(HEADERS)"
+	@echo IMAGE="$(IMAGE)"
+	@echo LINUX="$(LINUX)"
+	@echo LINUX_ELF="$(LINUX_ELF)"
+	@echo SELFTEST="$(SELFTEST)"
+	@echo CROSS_DEB_FILENAME="$(CROSS_DEB_FILENAME)"
+	@echo NATIVE_DEB_FILENAME="$(NATIVE_DEB_FILENAME)"
 
 # build linux
 # ------------------------------------------------------------------------------

--- a/shasumfile
+++ b/shasumfile
@@ -1,2 +1,2 @@
-e8d4d1882632eac7fd8e433b4eb4db014fd56e645fdad3b89be7d1ca4f20ca07  dep/linux-5.15.63-ctsi-2.tar.gz
-9a873345b9914940e7bf03a167da823910c8a2acadd818b780ffbd1a3edcc4c5  dep/riscv-pk-1.0.0-ctsi-1.tar.gz
+e8d4d1882632eac7fd8e433b4eb4db014fd56e645fdad3b89be7d1ca4f20ca07  linux-5.15.63-ctsi-2.tar.gz
+9a873345b9914940e7bf03a167da823910c8a2acadd818b780ffbd1a3edcc4c5  riscv-pk-1.0.0-ctsi-1.tar.gz

--- a/tools/template/cross-control.template
+++ b/tools/template/cross-control.template
@@ -1,0 +1,8 @@
+Package: linux-libc-dev-riscv64-cross
+Version: ARG_KERNEL_VERSION
+Architecture: any
+Priority: optional
+Section: devel
+Maintainer: Machine Reference Unit <https://discord.com/channels/600597137524391947/1107965671976992878>
+Provides: linux-kernel-headers-riscv64-cross, linux-libc-dev-riscv64-dcv1
+Description: Linux Kernel Headers for development (for cross-compiling)

--- a/tools/template/native-control.template
+++ b/tools/template/native-control.template
@@ -1,0 +1,8 @@
+Package: linux-libc-dev
+Version: ARG_KERNEL_VERSION
+Architecture: riscv64
+Priority: optional
+Section: devel
+Maintainer: Machine Reference Unit <https://discord.com/channels/600597137524391947/1107965671976992878>
+Provides: linux-kernel-headers
+Description: Linux Kernel Headers for development


### PR DESCRIPTION
- Remove `gh` tool usage, not needed now that repositories are public.
- Add an explicit `download` rule for explicit `make` calls.
- Upload artifacts for easy access of development builds.

close #12 