### PR TITLE
chore: bump to opensbi-1.3.1-ctsi-2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ DEP_DIR := dep
 KERNEL_VERSION ?= 6.5.9-ctsi-1
 KERNEL_SRCPATH := $(DEP_DIR)/linux-${KERNEL_VERSION}.tar.gz
 
-OPENSBI_VERSION ?= 1.3.1-ctsi-1
+OPENSBI_VERSION ?= 1.3.1-ctsi-2
 OPENSBI_SRCPATH := $(DEP_DIR)/opensbi-${OPENSBI_VERSION}.tar.gz
 
 CONTAINER_BASE := /opt/cartesi/kernel

--- a/shasumfile
+++ b/shasumfile
@@ -1,2 +1,2 @@
 bfc4d196b90592a2a6bef83ead9e196da6ab6d5978b48ee5e8ccf02913355bc2  dep/linux-6.5.9-ctsi-1.tar.gz
-267da33a34a023d9dcff3e7d9a8d58e7caefaff65441e38ff0114e4683dff176  dep/opensbi-1.3.1-ctsi-1.tar.gz
+35082380131117aa8424d1b81ca9e6e0280baa9bffbcf3f46080a652e4cb4385  dep/opensbi-1.3.1-ctsi-2.tar.gz


### PR DESCRIPTION
OpenSBI was adding a `\r` whenever it received a `\n` to the legacy putchar we use with HTIF console. The bumped version fixes this problem.